### PR TITLE
fix link to documentation

### DIFF
--- a/generate_perl_modules.pl
+++ b/generate_perl_modules.pl
@@ -102,7 +102,7 @@ foreach my $class ( keys(%$spec), 'Mouse', 'Keyboard' ) {
 
 Execute the $class\:\:$renamed playwright routine.
 
-See L<https://playwright.dev/api/class-$class#$class-$method> for more information.
+See L<https://playwright.dev/docs/api/class-$class#$class-$method> for more information.
 
 =cut
 


### PR DESCRIPTION
Currently the links to documentation look like playwright.dev/api/..., but it should be playwright.dev/docs/api/...