### PR TITLE
Add sed backup file to fix macos build, make successful commands quieter

### DIFF
--- a/clean_generated_files.sh
+++ b/clean_generated_files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-rm api.json; true
-rm bin/playwright_server; true
+rm -f api.json; true
+rm -f bin/playwright_server; true
 for module in $(git ls-files -o --exclude-standard lib/Playwright)
 do
-    rm $module; true
+    rm -f $module; true
 done

--- a/generate_api_json.sh
+++ b/generate_api_json.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 # Relies on the user having cloned the playwright repository in the directory directly adjacent to this repo
 ./clean_generated_files.sh
-mkdir bin; true
-pushd ../playwright
-git pull
+mkdir -p bin; true
+pushd ../playwright > /dev/null
+git pull -q
 node utils/doclint/generateApiJson.js > ../playwright-perl/api.json
-popd
+popd > /dev/null
 cp playwright_server bin/playwright_server
 API="$(<api.json)"
-sed -i -e '/%REPLACEME%/r api.json' -e 's/%REPLACEME%//g' bin/playwright_server
+sed -i.bak -e '/%REPLACEME%/r api.json' -e 's/%REPLACEME%//g' bin/playwright_server
+rm bin/playwright_server.bak
+
 # Make which work on windows
 cp bin/playwright_server bin/playwright_server.bat


### PR DESCRIPTION
Fixes issue #69 - the "sed -i" command acts different between GNU (linux) and BSD (macos). I also quieted the output of the scripts under normal operation (i.e. without errors). Thanks!