### PR TITLE
Added tests for cookies and remove the array processing of them

### DIFF
--- a/playwright_server
+++ b/playwright_server
@@ -214,7 +214,7 @@ app.post('/command', async (req, res) => {
                 commandResult = await subject[command](...args);
             }
 
-            if (Array.isArray(commandResult)) {
+            if (command !== 'cookies' && Array.isArray(commandResult)) {
                 for (var r of commandResult) {
                     // Some things like Locator arrays don't set themselves up properly
                     if (typeof r === 'object' && !Array.isArray(r) && r !== null) {

--- a/xt/author/playwright.t
+++ b/xt/author/playwright.t
@@ -41,13 +41,20 @@ my ($context) = @{$browser->contexts()};
 ok($context, "Got a browser context");
 
 # Load a URL in the tab
-my $res = $page->goto('http://troglodyne.net', { waitUntil => 'networkidle' });
+my $url = 'http://troglodyne.net';
+my $res = $page->goto($url, { waitUntil => 'networkidle' });
 ok($res->status(), "Was able to fetch a webpage");
 note $browser->version();
 
 # Put your hand in the jar
+$context->addCookies( [ { name => 'pw_testing', value => '1', url => $url }, { name => 'pw_cookie', value => 'trog', url => $url } ] );
 my $cookies = $context->cookies();
-ok($cookies, "was able to read the cookie jar");
+is( scalar @{ $cookies }, 2, "Was able to read the cookie jar");
+
+# Allow cookies to be returned in either order
+my $first = $cookies->[0]{ name } eq 'pw_testing' ? 0 : 1;
+is( $cookies->[$first]{ name }, 'pw_testing', "Retrieved first cookie");
+is( $cookies->[!$first || 0]{ value }, 'trog', "Retrieved second cookie");
 
 # Grab the main frame, in case this is a frameset
 my $frameset = $page->mainFrame();


### PR DESCRIPTION
Hi. I tried running some tests this morning on the new version, but I think cookies are broken. They shouldn't be processed like the other commands returning arrays (i.e. having a type and guid attached to them). I updated the playwright test to write and read cookies, which highlights the failure and fix.

I'm excited about trying the new Locator.all() functionality. Thank you!